### PR TITLE
Protect against no GC information

### DIFF
--- a/gcflow/src/main/java/org/gridkit/jvmtool/gcflow/GcAdapter.java
+++ b/gcflow/src/main/java/org/gridkit/jvmtool/gcflow/GcAdapter.java
@@ -85,7 +85,7 @@ class GcAdapter {
 	public void report() {
 		try {
 			GcInfo lastGc = gc.getLastGcInfo();
-			if (lastGc.getId() == gcCount) {
+			if (lastGc == null || lastGc.getId() == gcCount) {
 				return;
 			}
 			else {				


### PR DESCRIPTION
The call to getLastGcInfo() can return null if no garbage collection has happened yet. This change fixes some NullPointerExceptions I was getting trying to run the test while building the gcflow JAR on an OS X machine running Java 7.
