### PR TITLE
Fix for ttop CPU time comparator 

### DIFF
--- a/sjk-core/src/main/java/org/gridkit/jvmtool/MBeanCpuUsageReporter.java
+++ b/sjk-core/src/main/java/org/gridkit/jvmtool/MBeanCpuUsageReporter.java
@@ -327,7 +327,7 @@ public class MBeanCpuUsageReporter {
 		
 		@Override
 		public int compare(ThreadLine o1, ThreadLine o2) {
-			return Double.compare(o2.userT + o2.sysT, o1.userT + o1.userT);
+			return Double.compare(o2.userT + o2.sysT, o1.userT + o1.sysT);
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in CpuTimeComparator class.
Spotted because `java.lang.IllegalArgumentException: Comparison method violates its general contract!` was thrown.
