### PR TITLE
added '-all' parameter in mx tool to processing all matched MBeans

### DIFF
--- a/sjk-core/COMMANDS.md
+++ b/sjk-core/COMMANDS.md
@@ -130,6 +130,9 @@ MX command allows CLI access to MBean attributes and operations.
     > java -jar sjk.jar --help mx
     Usage: mx [options]
       Options:
+        -all, --allMatched
+           Process all matched MBeans
+           Default: false
         -a, --arguments
            Arguments for MBean operation invocation
            Default: []

--- a/sjk-core/src/main/java/org/gridkit/jvmtool/MBeanHelper.java
+++ b/sjk-core/src/main/java/org/gridkit/jvmtool/MBeanHelper.java
@@ -65,7 +65,7 @@ public class MBeanHelper {
 		for(MBeanOperationInfo oi: mbinfo.getOperations()) {
 			if (oi.getName().equalsIgnoreCase(operation) && oi.getSignature().length == params.length) {
 				if (op != null) {
-					throw new IllegalArgumentException("Ambigous " + operation + "/" + params.length + " operatition signature for " + bean);
+					throw new IllegalArgumentException("Ambiguous " + operation + "/" + params.length + " operatition signature for " + bean);
 				}
 				op = oi;
 			}

--- a/sjk-core/src/main/java/org/gridkit/jvmtool/SJK.java
+++ b/sjk-core/src/main/java/org/gridkit/jvmtool/SJK.java
@@ -151,7 +151,7 @@ public class SJK {
 				String cmdName = cmd.getCommandName();
 				Runnable cmdTask = cmd.newCommand(this);
 				if (commands.containsKey(cmdName)) {
-					fail("Ambigous implementation for '" + cmdName + "'");
+					fail("Ambiguous implementation for '" + cmdName + "'");
 				}
 				commands.put(cmdName, cmdTask);
 				parser.addCommand(cmdName, cmdTask);

--- a/sjk-core/src/test/java/org/gridkit/jvmtool/CliCheck.java
+++ b/sjk-core/src/test/java/org/gridkit/jvmtool/CliCheck.java
@@ -67,19 +67,19 @@ public class CliCheck {
 
 	@Test
 	public void ttop_self() {
-		
+
 		exec("ttop", "-p", PID);
 	}
 
 	@Test
 	public void ttop_top_N_cpu() {
-		
+
 		exec("ttop", "-p", "3380", "-o", "CPU", "-n", "10");
 	}
 
 	@Test
 	public void ttop_top_N_alloc() {
-		
+
 		exec("ttop", "-p", "3380", "-o", "ALLOC", "-n", "10");
 	}
 
@@ -108,23 +108,43 @@ public class CliCheck {
 		exec("mx", "-p", PID, "--info", "--bean", "*:type=HotSpotDiagnostic");
 	}
 
+    @Test
+    public void mx_info_all() {
+        exec("mx", "-p", PID, "--info", "-all", "--bean", "*:type=MemoryPool,*");
+    }
+
 	@Test
 	public void mx_get_diagnostic_ops() {
 		exec("mx", "-p", PID, "--get", "--bean", "*:type=HotSpotDiagnostic", "-f", "DiagnosticOptions");
 	}
+
+    @Test
+    public void mx_get_usage_threshold() {
+        exec("mx", "-p", PID, "--get", "-all", "--bean", "*:type=MemoryPool,name=PS*", "-f", "CollectionUsageThreshold");
+    }
 
 	@Test
 	public void mx_set_threading_alloc() {
 		exec("mx", "-p", PID, "--set", "--bean", "*:type=Threading", "-f", "ThreadAllocatedMemoryEnabled", "-v", "true");
 	}
 
+    @Test
+    public void mx_set_usage_threshold() {
+        exec("mx", "-p", PID, "--set", "-all", "--bean", "*:type=MemoryPool,name=PS*", "-f", "CollectionUsageThreshold", "-v", "1");
+    }
+
 	@Test
 	public void mx_get_thread_dump() {
 		exec("mx", "-p", PID, "--call", "--bean", "*:type=Threading", "-op", "dumpAllThreads", "-a", "true", "true");
 	}
+
+    @Test
+    public void mx_get_resetPeakUsage_all() {
+        exec("mx", "-p", PID, "--call", "-all", "--bean", "*:type=MemoryPool,*", "-op", "resetPeakUsage");
+    }
 	
 	@Test
-	public void mx_info_ambigous() {
+	public void mx_info_ambiguous() {
 		fail("mx", "-p", PID, "--info", "--bean", "*:type=GarbageCollector,*");
 	}
 	


### PR DESCRIPTION
Alexey, could you please poll my changes to your master branch?
I added -all parameter to process several matched MBeans. I hope it would be helpful to execute batch updates or call several identical operations in similar MBeans.
The change is backward compatible, since '-all' is false by default.
Please deploy new version in a success case.
