### PR TITLE
Added feature: custom jmx protocol connection

### DIFF
--- a/sjk-core/src/main/java/org/gridkit/jvmtool/JmxConnectionInfo.java
+++ b/sjk-core/src/main/java/org/gridkit/jvmtool/JmxConnectionInfo.java
@@ -99,7 +99,12 @@ public class JmxConnectionInfo {
 	@SuppressWarnings("resource")
 	private MBeanServerConnection connectJmx(String host, int port, Map<String, Object> props) {
 		try {
-			final String uri = "service:jmx:rmi:///jndi/rmi://" + host + ":" + port + "/jmxrmi";
+                        String proto = System.getProperty("jmx.service.protocol", "rmi");
+
+                        final String uri = proto == "rmi" ?
+                          "service:jmx:rmi:///jndi/rmi://" + host + ":" + port + "/jmxrmi" :
+                          "service:jmx:" + proto + "://" + host + ":" + port;
+                  
 			JMXServiceURL jmxurl = new JMXServiceURL(uri);						
 			JMXConnector conn = props == null ? JMXConnectorFactory.connect(jmxurl) : JMXConnectorFactory.connect(jmxurl, props);
 			// TODO credentials


### PR DESCRIPTION
Now supports Wildfly's [http-remoting](https://github.com/jbossas/remoting-jmx) jmx protocol.

Sample in-shell usage with wildfly client jars:
```bash
#!/usr/bin/env bash
set -eu
LIB_DIR="${WILDFLY_HOME:-/opt/wildfly}/bin/client"
JMX_PROTO="http-remoting-jmx"

java \
  -Djmx.service.protocol=${JMX_PROTO} \
  -Djava.ext.dirs=${LIB_DIR} \
  -jar "/opt/jvm-tools/sjk-plus.jar" $@
```