### PR TITLE
Memory allocations : Lazily compute the StackFrame hashcode

### DIFF
--- a/sjk-stacktrace/src/main/java/org/gridkit/jvmtool/stacktrace/StackFrame.java
+++ b/sjk-stacktrace/src/main/java/org/gridkit/jvmtool/stacktrace/StackFrame.java
@@ -25,7 +25,7 @@ public class StackFrame implements CharSequence, GenericStackElement {
     private final short textLen;
     private final short lineNumberDigits;
 
-    private final int hash;
+    private int hash;
 
     public StackFrame(StackTraceElement ste) {
         this(null, ste.getClassName(), ste.getMethodName(), ste.getFileName(), ste.getLineNumber());
@@ -67,7 +67,6 @@ public class StackFrame implements CharSequence, GenericStackElement {
         else {
             textLen = (short) len;
         }
-        hash = toString().hashCode();
     }
 
     private int calcLen() {
@@ -216,7 +215,11 @@ public class StackFrame implements CharSequence, GenericStackElement {
 
     @Override
     public int hashCode() {
-        return hash;
+        int h = hash;
+        if (h == 0) {
+        	hash = h = toString().hashCode();
+        }
+        return h;
     }
 
     @Override
@@ -231,7 +234,7 @@ public class StackFrame implements CharSequence, GenericStackElement {
             return false;
         }
         StackFrame other = (StackFrame) obj;
-        if (textLen != other.textLen || hash != other.hash) {
+        if (textLen != other.textLen || hashCode() != other.hashCode()) {
             return false;
         }
         if (fileName == null) {


### PR DESCRIPTION
Profiling of the stcap shows that ~45% of the memory is allocated in the
StackTraceWriterV2#write method.
The other 55% are mostly due to the JMX call, there's little we can do
here.

In the StackTraceWriterV2#write allocations, 80% come from the
StackFrame hashcode computation through the toString method: char buffer
+ String creation (which duplicate the array).

This patch lazily compute the StackFrame hashcode avoiding most of the
unneeded allocations.

In a simple stcap test, the memory allocated by StackTraceWriterV2#write
went from 1.27G to 130M

Note that allocations could also be improved by re-using the StackTraceElement that are re-created for each iteration.