### PR TITLE
ssa memory allocations

### DIFF
--- a/sjk-core/src/main/java/org/gridkit/jvmtool/cmd/StackSampleAnalyzerCmd.java
+++ b/sjk-core/src/main/java/org/gridkit/jvmtool/cmd/StackSampleAnalyzerCmd.java
@@ -224,9 +224,10 @@ public class StackSampleAnalyzerCmd implements CmdRef {
 			        EventReader<ThreadSnapshotEvent> reader = getFilteredReader();
 			        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 			        fmt.setTimeZone(timeZone());
+			        StringBuilder threadHeader = new StringBuilder();
+			        StringBuilder stackFrameBuffer = new StringBuilder();
 			        for(ThreadSnapshotEvent e: reader) {
 			            String timestamp = fmt.format(e.timestamp());
-			            StringBuilder threadHeader = new StringBuilder();
 			            threadHeader
 			                .append("Thread [")
 			                .append(e.threadId())
@@ -241,9 +242,12 @@ public class StackSampleAnalyzerCmd implements CmdRef {
 			            System.out.println(threadHeader);
 			            StackFrameList trace = e.stackTrace();
 			            for(StackFrame frame: trace) {
-			                System.out.println(frame);
+			            	frame.toString(stackFrameBuffer);
+			                System.out.println(stackFrameBuffer);
+			                stackFrameBuffer.setLength(0);
 			            }
 			            System.out.println();
+			            threadHeader.setLength(0);
 			        }
 				    
 				} catch (Exception e) {


### PR DESCRIPTION
Re-use buffer between iteration
use StackFrame#toString(StringBuilder) instead toString() which
allocates more memory.

with this patch running ssa --print on a reference dump reduce the
memory allocations from 1.21G to 846M