### PR TITLE
Removed assertion roulette (test smell)

### DIFF
--- a/sjk-core/src/test/java/org/gridkit/jvmtool/cmd/StackSampleAnalyzerCmdTest.java
+++ b/sjk-core/src/test/java/org/gridkit/jvmtool/cmd/StackSampleAnalyzerCmdTest.java
@@ -15,31 +15,75 @@ public class StackSampleAnalyzerCmdTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testDateFormaterToString() {
+  public void testNullTimeZoneDateFormaterToString(){
     Assert.assertEquals("", new DateFormater(null).toString(null));
+  }
+
+  @Test
+  public void testDateFormaterToString(){
     Assert.assertEquals("2019.02.18_17:17:14", new DateFormater(TimeZone.getTimeZone("UTC")).toString(1550510234000L));
+  }
+
+  @Test
+  public void testDateFormaterToStringException() {
     thrown.expect(NullPointerException.class);
     new DateFormater(null).toString(0L);
     // Exception thrown
   }
 
   @Test
-  public void testDecimalFormaterToString() {
+  public void testDecimalFormaterToStringNullParam() {
     Assert.assertEquals("", new DecimalFormater(9).toString(null));
+  }
+
+  @Test
+  public void testDecimalFormaterToStringNonNumericParam() {
     Assert.assertEquals("", new DecimalFormater(9).toString("text"));
+  }
+
+  @Test
+  public void testDecimalFormaterToStringLongParam() {
     Assert.assertEquals("\t4", new DecimalFormater(9).toString(4L));
+  }
+
+  @Test
+  public void testDecimalFormaterToStringNumericParam() {
     Assert.assertEquals("\t4.000000000", new DecimalFormater(9).toString(4));
   }
 
   @Test
-  public void testMemRateFormaterToString() {
+  public void testMemRateFormaterToStringNullParam() {
     Assert.assertEquals("", new MemRateFormater().toString(null));
+  }
+
+  @Test
+  public void testMemRateFormaterToStringNaNParam() {
     Assert.assertEquals("", new MemRateFormater().toString(Double.NaN));
+  }
+
+  @Test
+  public void testMemRateFormaterToStringNoRate() {
     Assert.assertEquals("0/s", new MemRateFormater().toString(0));
+  }
+
+  @Test
+  public void testMemRateFormaterToString() {
     Assert.assertEquals("9/s", new MemRateFormater().toString(9));
+  }
+
+  @Test
+  public void testMemRateFormaterToStringKps() {
     Assert.assertEquals("19k/s", new MemRateFormater().toString(20475));
+  }
+
+  @Test
+  public void testMemRateFormaterToStringMps() {
     Assert.assertEquals("70m/s", new MemRateFormater().toString(74160839));
-    Assert.assertEquals("10g/s", new MemRateFormater().toString(10737418240l));
+  }
+
+  @Test
+  public void testMemRateFormaterToStringGps() {
+    Assert.assertEquals("10g/s", new MemRateFormater().toString(10737418240L));
   }
 
 }


### PR DESCRIPTION
This is a test refactoring. The Assertion Roulette occurs when a test method has multiple non-documented assertions. Various assertion statements in a test method without a descriptive message impacts the test maintainability (also readability and understandability) as it is not possible to understand the reason for the failure of the test.

The idea is to keep only one assertion per test method and thus add more semantic to the test name.

No assertion was changed or removed from the original version.