### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,44 +8,22 @@ on:
 
 jobs:
 
-  build8:
+  build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 8.0.192, 8, 11.0.3, 11, 15 ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
-        distribution: 'adopt'
+        java-version: ${{ matrix.java-version }}
+        distribution: 'zulu'
     - name: Build with Maven
+      if: ${{ !startsWith(matrix.java-version, '15') }}
       run: mvn -B package --file pom.xml -DdisableToolchain
-
-  build11:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml -DdisableToolchain
-
-  build15:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 15
-      uses: actions/setup-java@v2
-      with:
-        java-version: '15'
-        distribution: 'adopt'
-    - name: Build with Maven
+    - name: Build with Maven with help active profile
+      if: ${{ startsWith(matrix.java-version, '15') }}
       run: mvn -B help:active-profiles && mvn -B package --file pom.xml -DdisableToolchain


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switch the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added are fixed (major) release version(s) such as `JDK 11.0.3`. This is often a good practice whenever a build/test triggers (push/pull events) that help determine if the latest (`JDK 11`) had failed the from the **latest build** vs something in **your code** caused (introduced). In addition to the workflow I consolidated the job by using a build matrix. 
:-)

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.