### PR TITLE
Dynamically adjust the number of Forked VM based on the number of CPU cores

### DIFF
--- a/sjk-core/pom.xml
+++ b/sjk-core/pom.xml
@@ -108,7 +108,7 @@
               </execution>
             </executions>
             <configuration>
-              <forkCount>1</forkCount>
+              <forkCount>1.5C</forkCount>
               <reuseForks>false</reuseForks>
               <includes>
                 <include>**/CliCheck.java</include>
@@ -138,7 +138,7 @@
               </execution>
             </executions>
             <configuration>
-              <forkCount>1</forkCount>
+              <forkCount>1.5C</forkCount>
               <reuseForks>false</reuseForks>
               <includes>
                 <include>**/CliCheck.java</include>
@@ -169,7 +169,7 @@
               </execution>
             </executions>
             <configuration>
-              <forkCount>1</forkCount>
+              <forkCount>1.5C</forkCount>
               <reuseForks>false</reuseForks>
               <includes>
                 <include>**/CliCheck.java</include>
@@ -200,7 +200,7 @@
               </execution>
             </executions>
             <configuration>
-              <forkCount>1</forkCount>
+              <forkCount>1.5C</forkCount>
               <reuseForks>false</reuseForks>
               <includes>
                 <include>**/CliCheck.java</include>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
