### PR TITLE
fix(sec): upgrade org.apache.logging.log4j:log4j-core to 2.17.1

### DIFF
--- a/sjk-test/pom.xml
+++ b/sjk-test/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.14.1</version>
+      <version>2.17.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.logging.log4j:log4j-core 2.14.1
- [CVE-2021-44832](https://www.oscs1024.com/hd/CVE-2021-44832)


### What did I do？
Upgrade org.apache.logging.log4j:log4j-core from 2.14.1 to 2.17.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS