### PR TITLE
fix: Using `-h` as default instead of null input, so that npe won't happen when no command was entered.

### DIFF
--- a/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
+++ b/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
@@ -124,7 +124,7 @@ public class CommandLauncher {
                 }
             }
             else {
-    
+
                 String parsedCommand = parser.getParsedCommand();
                 if (parsedCommand == null) {
                     parsedCommand = "-h";

--- a/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
+++ b/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
@@ -118,18 +118,14 @@ public class CommandLauncher {
                     parser.usage(cmd);
                 }
             }
-            else if (listCommands) {
+            else if (listCommands || parser.getParsedCommand() == null) {
                 for(String cmd: commands.keySet()) {
                     System.out.println(String.format("%8s - %s", cmd, parser.getCommandDescription(cmd)));
                 }
             }
             else {
 
-                String parsedCommand = parser.getParsedCommand();
-                if (parsedCommand == null) {
-                    parsedCommand = "--commands";
-                }
-                Runnable cmd = commands.get(parsedCommand);
+                Runnable cmd = commands.get(parser.getParsedCommand());
 
                 if (cmd == null) {
                     failAndPrintUsage();

--- a/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
+++ b/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
@@ -124,8 +124,12 @@ public class CommandLauncher {
                 }
             }
             else {
-
-                Runnable cmd = commands.get(parser.getParsedCommand());
+    
+                String parsedCommand = parser.getParsedCommand();
+                if (parsedCommand == null) {
+                    parsedCommand = "-h";
+                }
+                Runnable cmd = commands.get(parsedCommand);
 
                 if (cmd == null) {
                     failAndPrintUsage();

--- a/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
+++ b/sjk-cli/src/main/java/org/gridkit/jvmtool/cli/CommandLauncher.java
@@ -127,7 +127,7 @@ public class CommandLauncher {
 
                 String parsedCommand = parser.getParsedCommand();
                 if (parsedCommand == null) {
-                    parsedCommand = "-h";
+                    parsedCommand = "--commands";
                 }
                 Runnable cmd = commands.get(parsedCommand);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55729509/203889521-0dc8150b-17d4-494c-9904-5bbe3924ec45.png)
